### PR TITLE
feat(queue): Redis + rq queue abstraction

### DIFF
--- a/prod/docker-compose.yml
+++ b/prod/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.8"
+
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  redis_data:

--- a/prod/requirements.txt
+++ b/prod/requirements.txt
@@ -5,5 +5,7 @@ pydantic-settings==2.1.0
 python-dotenv==1.0.0
 mysql-connector-python==9.0.0
 SQLAlchemy>=2.0,<3.0
+redis>=5.0,<6.0
+rq>=1.16,<2.0
 google-api-python-client==2.115.0
 jinja2==3.1.3

--- a/prod/shared/queue/__init__.py
+++ b/prod/shared/queue/__init__.py
@@ -1,0 +1,3 @@
+from shared.queue.publisher import enqueue_video_upload, enqueue_notification
+
+__all__ = ["enqueue_video_upload", "enqueue_notification"]

--- a/prod/shared/queue/config.py
+++ b/prod/shared/queue/config.py
@@ -1,0 +1,32 @@
+"""Redis connection configuration."""
+
+from __future__ import annotations
+
+import os
+
+from redis import Redis
+
+_redis: Redis | None = None
+
+REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+
+# Queue names
+QUEUE_PUBLISHING = "publishing"
+QUEUE_NOTIFICATIONS = "notifications"
+QUEUE_VOICE = "voice"
+
+
+def get_redis() -> Redis:
+    """Get or create the global Redis connection."""
+    global _redis
+    if _redis is None:
+        _redis = Redis.from_url(REDIS_URL, decode_responses=False)
+    return _redis
+
+
+def close_redis() -> None:
+    """Close Redis connection (for shutdown)."""
+    global _redis
+    if _redis is not None:
+        _redis.close()
+        _redis = None

--- a/prod/shared/queue/publisher.py
+++ b/prod/shared/queue/publisher.py
@@ -1,0 +1,48 @@
+"""Queue publisher — enqueue jobs for workers."""
+
+from __future__ import annotations
+
+from rq import Queue
+
+from shared.queue.config import get_redis, QUEUE_PUBLISHING, QUEUE_NOTIFICATIONS, QUEUE_VOICE
+from shared.queue.types import VideoUploadPayload, NotificationPayload, VoiceChangePayload
+
+
+def _get_queue(name: str) -> Queue:
+    return Queue(name, connection=get_redis())
+
+
+def enqueue_video_upload(payload: VideoUploadPayload, **kwargs) -> str:
+    """Enqueue a video upload job. Returns job ID."""
+    q = _get_queue(QUEUE_PUBLISHING)
+    job = q.enqueue(
+        "workers.publishing_worker.process_upload",
+        payload,
+        job_timeout="30m",
+        **kwargs,
+    )
+    return job.id
+
+
+def enqueue_notification(payload: NotificationPayload, **kwargs) -> str:
+    """Enqueue a notification job. Returns job ID."""
+    q = _get_queue(QUEUE_NOTIFICATIONS)
+    job = q.enqueue(
+        "workers.notification_worker.send_notification",
+        payload,
+        job_timeout="2m",
+        **kwargs,
+    )
+    return job.id
+
+
+def enqueue_voice_change(payload: VoiceChangePayload, **kwargs) -> str:
+    """Enqueue a voice change job. Returns job ID."""
+    q = _get_queue(QUEUE_VOICE)
+    job = q.enqueue(
+        "workers.voice_worker.process_voice_change",
+        payload,
+        job_timeout="30m",
+        **kwargs,
+    )
+    return job.id

--- a/prod/shared/queue/types.py
+++ b/prod/shared/queue/types.py
@@ -1,0 +1,40 @@
+"""Payload types for queue messages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+@dataclass
+class VideoUploadPayload:
+    task_id: int
+    channel_id: int
+    source_file_path: str
+    title: str
+    description: str | None = None
+    keywords: str | None = None
+    thumbnail_path: str | None = None
+    post_comment: str | None = None
+    media_type: str = "video"
+    scheduled_at: datetime | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class NotificationPayload:
+    channel: str  # "telegram" | "email"
+    recipient: str
+    subject: str | None = None
+    message: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class VoiceChangePayload:
+    task_id: int
+    source_file_path: str
+    output_file_path: str
+    voice_model: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)


### PR DESCRIPTION
## Summary
- `shared/queue/` package: Redis config, typed payloads, publisher with 3 queues (publishing, notifications, voice)
- Docker Compose with Redis 7 Alpine (persistent AOF, healthcheck)
- `redis>=5.0` + `rq>=1.16` added to requirements

## Test plan
- [ ] `docker compose up redis` starts and responds to `redis-cli ping`
- [ ] `from shared.queue.publisher import enqueue_video_upload` imports cleanly
- [ ] Enqueue/dequeue test message via Python REPL

Closes #77