### PR TITLE
feat(auth): JWT authentication

### DIFF
--- a/prod/app/api/deps.py
+++ b/prod/app/api/deps.py
@@ -1,0 +1,36 @@
+"""FastAPI dependencies — authentication."""
+
+from __future__ import annotations
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from app.core.security import decode_access_token
+from shared.db.repositories import user_repo
+
+_bearer = HTTPBearer(auto_error=False)
+
+
+async def get_current_user(
+    creds: HTTPAuthorizationCredentials | None = Depends(_bearer),
+) -> dict:
+    """Validate Bearer token and return the authenticated user dict.
+
+    Raises 401 if token is missing/invalid or user not found.
+    """
+    if creds is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+
+    payload = decode_access_token(creds.credentials)
+    if payload is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    user_id: int | None = payload.get("sub")
+    if user_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload")
+
+    user = user_repo.get_user_by_id(int(user_id))
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+
+    return user

--- a/prod/app/api/endpoints/auth.py
+++ b/prod/app/api/endpoints/auth.py
@@ -1,0 +1,58 @@
+"""Authentication endpoints — login, register, me."""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.api.deps import get_current_user
+from app.core.security import create_access_token, hash_password, verify_password
+from app.schemas.auth import LoginRequest, RegisterRequest, TokenResponse, UserResponse
+from shared.db.repositories import user_repo
+
+router = APIRouter()
+
+
+@router.post("/login", response_model=TokenResponse)
+async def login(body: LoginRequest):
+    user = user_repo.get_user_by_email(body.email)
+    if not user or not verify_password(body.password, user["password_hash"]):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+
+    user_repo.update_last_login(user["id"])
+    token = create_access_token({"sub": user["id"]})
+    return TokenResponse(access_token=token)
+
+
+@router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
+async def register(body: RegisterRequest):
+    if user_repo.get_user_by_email(body.email):
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Email already registered")
+    if user_repo.get_user_by_username(body.username):
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Username already taken")
+
+    user_id = user_repo.create_user(
+        uuid=str(uuid.uuid4()),
+        username=body.username,
+        email=body.email,
+        password_hash=hash_password(body.password),
+        auth_key=secrets.token_hex(16),
+        display_name=body.display_name,
+    )
+    token = create_access_token({"sub": user_id})
+    return TokenResponse(access_token=token)
+
+
+@router.get("/me", response_model=UserResponse)
+async def me(user: dict = Depends(get_current_user)):
+    return UserResponse(
+        id=user["id"],
+        uuid=user["uuid"],
+        username=user["username"],
+        email=user["email"],
+        display_name=user.get("display_name"),
+        avatar_url=user.get("avatar_url"),
+        timezone=user.get("timezone"),
+    )

--- a/prod/app/api/routes.py
+++ b/prod/app/api/routes.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter
 
-from app.api.endpoints import channels, items
+from app.api.endpoints import auth, channels, items
 
 router = APIRouter()
 
+router.include_router(auth.router, prefix="/auth", tags=["auth"])
 router.include_router(items.router, prefix="/items", tags=["items"])
 router.include_router(channels.router, prefix="/channels", tags=["channels"])

--- a/prod/app/core/security.py
+++ b/prod/app/core/security.py
@@ -1,0 +1,39 @@
+"""JWT token creation and verification."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
+from typing import Any
+
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+SECRET_KEY = os.environ.get("JWT_SECRET_KEY", "change-me-in-production")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.environ.get("JWT_EXPIRE_MINUTES", "1440"))  # 24h
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return pwd_context.verify(plain, hashed)
+
+
+def create_access_token(data: dict[str, Any], expires_delta: timedelta | None = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode["exp"] = expire
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def decode_access_token(token: str) -> dict[str, Any] | None:
+    """Decode and validate JWT. Returns payload or None on failure."""
+    try:
+        return jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except JWTError:
+        return None

--- a/prod/app/schemas/auth.py
+++ b/prod/app/schemas/auth.py
@@ -1,0 +1,32 @@
+"""Auth request/response schemas."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, EmailStr
+
+
+class LoginRequest(BaseModel):
+    email: str
+    password: str
+
+
+class RegisterRequest(BaseModel):
+    username: str
+    email: str
+    password: str
+    display_name: str | None = None
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class UserResponse(BaseModel):
+    id: int
+    uuid: str
+    username: str
+    email: str
+    display_name: str | None = None
+    avatar_url: str | None = None
+    timezone: str | None = None

--- a/prod/requirements.txt
+++ b/prod/requirements.txt
@@ -12,3 +12,5 @@ google-api-python-client==2.115.0
 google-auth>=2.27,<3.0
 google-auth-oauthlib>=1.2,<2.0
 jinja2==3.1.3
+python-jose[cryptography]>=3.3,<4.0
+passlib[bcrypt]>=1.7,<2.0

--- a/prod/shared/db/repositories/user_repo.py
+++ b/prod/shared/db/repositories/user_repo.py
@@ -1,0 +1,101 @@
+"""User repository — CRUD for platform_users."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import select, insert, text
+
+from shared.db.connection import get_connection
+from shared.db.models import platform_users
+
+
+def get_user_by_id(user_id: int) -> dict[str, Any] | None:
+    t = platform_users
+    cols = [
+        t.c.id, t.c.uuid, t.c.username, t.c.email,
+        t.c.password_hash, t.c.display_name, t.c.avatar_url,
+        t.c.status, t.c.timezone, t.c.created_at, t.c.updated_at,
+    ]
+    stmt = select(*cols).where(t.c.id == user_id)
+    with get_connection() as conn:
+        row = conn.execute(stmt).fetchone()
+    if not row:
+        return None
+    return _row_to_dict(row)
+
+
+def get_user_by_email(email: str) -> dict[str, Any] | None:
+    t = platform_users
+    cols = [
+        t.c.id, t.c.uuid, t.c.username, t.c.email,
+        t.c.password_hash, t.c.display_name, t.c.avatar_url,
+        t.c.status, t.c.timezone, t.c.created_at, t.c.updated_at,
+    ]
+    stmt = select(*cols).where(t.c.email == email)
+    with get_connection() as conn:
+        row = conn.execute(stmt).fetchone()
+    if not row:
+        return None
+    return _row_to_dict(row)
+
+
+def get_user_by_username(username: str) -> dict[str, Any] | None:
+    t = platform_users
+    cols = [
+        t.c.id, t.c.uuid, t.c.username, t.c.email,
+        t.c.password_hash, t.c.display_name, t.c.avatar_url,
+        t.c.status, t.c.timezone, t.c.created_at, t.c.updated_at,
+    ]
+    stmt = select(*cols).where(t.c.username == username)
+    with get_connection() as conn:
+        row = conn.execute(stmt).fetchone()
+    if not row:
+        return None
+    return _row_to_dict(row)
+
+
+def create_user(
+    uuid: str,
+    username: str,
+    email: str,
+    password_hash: str,
+    auth_key: str,
+    display_name: str | None = None,
+) -> int:
+    """Insert a new user. Returns user id."""
+    stmt = insert(platform_users).values(
+        uuid=uuid,
+        username=username,
+        email=email,
+        password_hash=password_hash,
+        auth_key=auth_key,
+        display_name=display_name or username,
+    )
+    with get_connection() as conn:
+        result = conn.execute(stmt)
+        return result.lastrowid
+
+
+def update_last_login(user_id: int) -> None:
+    sql = text(
+        "UPDATE platform_users SET last_login_at = NOW() WHERE id = :uid"
+    )
+    with get_connection() as conn:
+        conn.execute(sql, {"uid": user_id})
+
+
+def _row_to_dict(row) -> dict[str, Any]:
+    return {
+        "id": row[0],
+        "uuid": row[1],
+        "username": row[2],
+        "email": row[3],
+        "password_hash": row[4],
+        "display_name": row[5],
+        "avatar_url": row[6],
+        "status": row[7],
+        "timezone": row[8],
+        "created_at": row[9],
+        "updated_at": row[10],
+    }


### PR DESCRIPTION
## Summary
- JWT auth with login/register/me endpoints under `/api/v1/auth/`
- `get_current_user` FastAPI dependency for protecting endpoints
- User repository in shared/db layer
- bcrypt password hashing, 24h token expiry (configurable via `JWT_EXPIRE_MINUTES`)
- `python-jose[cryptography]` + `passlib[bcrypt]` added to requirements

## Test plan
- [ ] `POST /api/v1/auth/register` → creates user → returns JWT
- [ ] `POST /api/v1/auth/login` → valid creds → returns JWT
- [ ] `GET /api/v1/auth/me` with Bearer token → returns user info
- [ ] Invalid/expired token → 401
- [ ] Existing channels endpoints still work without auth (no breaking change)

Closes #80