### PR TITLE
feat(api): task management endpoints + dual-write

### DIFF
--- a/prod/app/api/endpoints/tasks.py
+++ b/prod/app/api/endpoints/tasks.py
@@ -1,0 +1,105 @@
+"""Task management endpoints with dual-write (DB + Redis queue)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.api.deps import get_current_user
+from app.schemas.task import TaskCreate, TaskListResponse, TaskResponse, TaskUpdate
+from shared.db.repositories import task_repo
+from shared.queue.publisher import enqueue_video_upload
+from shared.queue.types import VideoUploadPayload
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.post("/", response_model=TaskResponse, status_code=status.HTTP_201_CREATED)
+async def create_task(body: TaskCreate, user: dict = Depends(get_current_user)):
+    """Create a new upload task. Dual-write: DB + Redis queue."""
+    task_id = task_repo.create_task(
+        channel_id=body.channel_id,
+        source_file_path=body.source_file_path,
+        title=body.title,
+        scheduled_at=body.scheduled_at,
+        media_type=body.media_type,
+        thumbnail_path=body.thumbnail_path,
+        description=body.description,
+        keywords=body.keywords,
+        post_comment=body.post_comment,
+        legacy_add_info=body.legacy_add_info,
+    )
+    if task_id is None:
+        raise HTTPException(status_code=500, detail="Failed to create task")
+
+    # Dual-write: also enqueue to Redis for the new worker
+    try:
+        enqueue_video_upload(VideoUploadPayload(
+            task_id=task_id,
+            channel_id=body.channel_id,
+            source_file_path=body.source_file_path,
+            title=body.title,
+            description=body.description,
+            keywords=body.keywords,
+            thumbnail_path=body.thumbnail_path,
+            post_comment=body.post_comment,
+            media_type=body.media_type,
+            scheduled_at=body.scheduled_at,
+        ))
+    except Exception:
+        logger.warning("Redis enqueue failed for task %d — legacy worker will pick it up", task_id)
+
+    task = task_repo.get_task(task_id)
+    return TaskResponse(**task)
+
+
+@router.get("/", response_model=TaskListResponse)
+async def list_tasks(
+    status_filter: int | None = Query(None, alias="status"),
+    channel_id: int | None = None,
+    limit: int = Query(50, ge=1, le=500),
+    user: dict = Depends(get_current_user),
+):
+    tasks = task_repo.get_all_tasks(status=status_filter, channel_id=channel_id, limit=limit)
+    return TaskListResponse(
+        items=[TaskResponse(**t) for t in tasks],
+        total=len(tasks),
+    )
+
+
+@router.get("/{task_id}", response_model=TaskResponse)
+async def get_task(task_id: int, user: dict = Depends(get_current_user)):
+    task = task_repo.get_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return TaskResponse(**task)
+
+
+@router.put("/{task_id}", response_model=TaskResponse)
+async def update_task(task_id: int, body: TaskUpdate, user: dict = Depends(get_current_user)):
+    task = task_repo.get_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    if body.status is not None:
+        task_repo.update_task_status(task_id, body.status, error_message=body.error_message)
+
+    updated = task_repo.get_task(task_id)
+    return TaskResponse(**updated)
+
+
+@router.get("/{task_id}/status")
+async def get_task_status(task_id: int, user: dict = Depends(get_current_user)):
+    task = task_repo.get_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return {
+        "task_id": task["id"],
+        "status": task["status"],
+        "upload_id": task.get("upload_id"),
+        "error_message": task.get("error_message"),
+        "completed_at": task.get("completed_at"),
+    }

--- a/prod/app/api/routes.py
+++ b/prod/app/api/routes.py
@@ -1,9 +1,10 @@
 from fastapi import APIRouter
 
-from app.api.endpoints import auth, channels, items
+from app.api.endpoints import auth, channels, items, tasks
 
 router = APIRouter()
 
 router.include_router(auth.router, prefix="/auth", tags=["auth"])
 router.include_router(items.router, prefix="/items", tags=["items"])
 router.include_router(channels.router, prefix="/channels", tags=["channels"])
+router.include_router(tasks.router, prefix="/tasks", tags=["tasks"])

--- a/prod/app/schemas/task.py
+++ b/prod/app/schemas/task.py
@@ -1,0 +1,50 @@
+"""Task request/response schemas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class TaskCreate(BaseModel):
+    channel_id: int
+    source_file_path: str
+    title: str
+    scheduled_at: datetime
+    media_type: str = "video"
+    thumbnail_path: str | None = None
+    description: str | None = None
+    keywords: str | None = None
+    post_comment: str | None = None
+    legacy_add_info: dict[str, Any] | None = None
+
+
+class TaskUpdate(BaseModel):
+    status: int | None = None
+    error_message: str | None = None
+
+
+class TaskResponse(BaseModel):
+    id: int
+    channel_id: int
+    media_type: str | None = None
+    status: int
+    source_file_path: str | None = None
+    thumbnail_path: str | None = None
+    title: str | None = None
+    description: str | None = None
+    keywords: str | None = None
+    post_comment: str | None = None
+    scheduled_at: datetime | None = None
+    completed_at: datetime | None = None
+    upload_id: str | None = None
+    error_message: str | None = None
+    retry_count: int | None = None
+    created_at: datetime | None = None
+
+
+class TaskListResponse(BaseModel):
+    items: list[TaskResponse]
+    total: int


### PR DESCRIPTION
## Summary
- Full task CRUD under `/api/v1/tasks/` with JWT auth
- **Dual-write pattern**: POST creates task in DB _and_ enqueues to Redis — if Redis fails, legacy worker still processes from DB
- Pydantic schemas for request validation and response serialization
- Status endpoint for lightweight polling

## Test plan
- [ ] `POST /tasks/` with JWT → task created in DB + enqueued to Redis
- [ ] `GET /tasks/` → lists tasks with filtering
- [ ] `PUT /tasks/{id}` → updates status
- [ ] Redis down → task still created in DB, warning logged
- [ ] Legacy worker on prod unaffected (reads same DB table)

Closes #81